### PR TITLE
Directly open review prompt from settings

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -40,18 +40,9 @@ export default function Settings({ onBack, appVersion }: SettingsProps) {
   };
 
   const handleReviewPress = () => {
-    Alert.alert(
-      'Leave a Review ⭐',
-      'Your 5-star review would help me. Would you like to leave a review on the App Store?',
-      [
-        { text: 'Maybe Later', style: 'cancel' },
-        { text: 'Leave Review ⭐', onPress: () => {
-          handleOpenURL(
-            'https://apps.apple.com/mt/app/universal-s3-client/id6747045182?action=write-review',
-            'App Store Review'
-          );
-        }}
-      ]
+    handleOpenURL(
+      'https://apps.apple.com/mt/app/universal-s3-client/id6747045182?action=write-review',
+      'App Store Review'
     );
   };
 


### PR DESCRIPTION
Remove the review confirmation pop-up to directly redirect users to the App Store for reviews.

---

[Open in Web](https://cursor.com/agents?id=bc-013d1904-b20f-438e-8cd0-eb02ce8a3ac7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-013d1904-b20f-438e-8cd0-eb02ce8a3ac7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)