### PR TITLE
Remove whitespace above settings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import './src/utils/polyfills';
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, View, Alert, SafeAreaView, StatusBar, ActivityIndicator } from 'react-native';
 import { Provider as PaperProvider, Text, Portal, Modal, FAB, Appbar } from 'react-native-paper';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import ProviderForm from './src/components/ProviderForm';
 import ProviderList from './src/components/ProviderList';
 import ProviderDetails from './src/components/ProviderDetails';
@@ -226,10 +227,12 @@ export default function App() {
 
     if (showSettings) {
       return (
-        <Settings
-          onBack={() => setShowSettings(false)}
-          appVersion="1.1.0"
-        />
+        <View style={{ flex: 1, backgroundColor: '#f8f8f8' }}>
+          <Settings
+            onBack={() => setShowSettings(false)}
+            appVersion="1.1.0"
+          />
+        </View>
       );
     }
 
@@ -304,22 +307,35 @@ export default function App() {
   };
 
   return (
-    <PaperProvider>
-      <SafeAreaView style={styles.safeArea}>
-        <StatusBar barStyle="dark-content" />
-        {isOffline && (
-          <View style={{ backgroundColor: '#ff5252', padding: 8 }}>
-            <Text style={{ color: 'white', textAlign: 'center', fontWeight: 'bold' }}>Network error: you are offline</Text>
+    <SafeAreaProvider>
+      <PaperProvider>
+        {showSettings ? (
+          <View style={styles.fullScreen}>
+            <StatusBar barStyle="dark-content" backgroundColor="#f8f8f8" />
+            {renderContent()}
           </View>
+        ) : (
+          <SafeAreaView style={styles.safeArea}>
+            <StatusBar barStyle="dark-content" />
+            {isOffline && (
+              <View style={{ backgroundColor: '#ff5252', padding: 8 }}>
+                <Text style={{ color: 'white', textAlign: 'center', fontWeight: 'bold' }}>Network error: you are offline</Text>
+              </View>
+            )}
+            {renderContent()}
+          </SafeAreaView>
         )}
-        {renderContent()}
-      </SafeAreaView>
-    </PaperProvider>
+      </PaperProvider>
+    </SafeAreaProvider>
   );
 }
 
 const styles = StyleSheet.create({
   safeArea: {
+    flex: 1,
+    backgroundColor: '#f8f8f8',
+  },
+  fullScreen: {
     flex: 1,
     backgroundColor: '#f8f8f8',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-native": "0.76.9",
         "react-native-get-random-values": "^1.11.0",
         "react-native-paper": "^5.13.4",
-        "react-native-safe-area-context": "4.12.0"
+        "react-native-safe-area-context": "^4.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-native": "0.76.9",
     "react-native-get-random-values": "^1.11.0",
     "react-native-paper": "^5.13.4",
-    "react-native-safe-area-context": "4.12.0"
+    "react-native-safe-area-context": "^4.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, ScrollView, Linking, Alert } from 'react-native';
 import { Text, Button, Appbar, Card, Divider } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface SettingsProps {
   onBack: () => void;
@@ -8,6 +9,8 @@ interface SettingsProps {
 }
 
 export default function Settings({ onBack, appVersion }: SettingsProps) {
+  const insets = useSafeAreaInsets();
+  
   const handleOpenURL = (url: string, serviceName: string) => {
     Linking.canOpenURL(url)
       .then((supported) => {
@@ -47,7 +50,7 @@ export default function Settings({ onBack, appVersion }: SettingsProps) {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top }]}>
       <Appbar.Header style={styles.header}>
         <Appbar.Content title="Settings" />
         <Appbar.Action 
@@ -57,7 +60,7 @@ export default function Settings({ onBack, appVersion }: SettingsProps) {
         />
       </Appbar.Header>
       
-      <ScrollView style={styles.content} contentContainerStyle={styles.contentContainer}>
+      <ScrollView style={styles.content} contentContainerStyle={styles.contentContainer} showsVerticalScrollIndicator={false}>
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>About the Developer</Text>
           <Text style={styles.description}>
@@ -128,16 +131,21 @@ const styles = StyleSheet.create({
     backgroundColor: '#f8f8f8',
   },
   header: {
-    height: 'auto', // Flexible height based on content
-    minHeight: 48, // Minimum height for touch targets
-    paddingVertical: 8, // Reduced vertical padding
+    backgroundColor: '#f8f8f8',
+    elevation: 0,
+    shadowOpacity: 0,
+    borderBottomWidth: 0,
+    height: 56,
+    justifyContent: 'center',
   },
   content: {
     flex: 1,
+    backgroundColor: '#f8f8f8',
   },
   contentContainer: {
     flexGrow: 1,
     padding: 16,
+    paddingTop: 0,
   },
   card: {
     marginBottom: 24,


### PR DESCRIPTION
Eliminate persistent white space above the Settings screen by refactoring its layout to use `useSafeAreaInsets` and conditionally rendering its container.

The `SafeAreaView` in `App.tsx` was causing a fixed top padding that remained visible even when the `Settings` screen scrolled. By allowing `Settings` to manage its own safe area insets and removing the parent `SafeAreaView` when `Settings` is active, the layout is now fully controlled by the `Settings` component, resolving the visual glitch.

---

[Open in Web](https://cursor.com/agents?id=bc-15355a3f-db62-4598-839e-60eff6498d1f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-15355a3f-db62-4598-839e-60eff6498d1f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)