### PR TITLE
Simplify bucket header display

### DIFF
--- a/src/components/ProviderDetails.tsx
+++ b/src/components/ProviderDetails.tsx
@@ -851,7 +851,7 @@ function ProviderDetails({ provider, onBack }: ProviderDetailsProps) {
           disabled={pathHistory.length === 0}
           style={styles.backButton} 
         />
-        <Text style={styles.headerTitle}>{provider.name}</Text>
+        <Text style={styles.headerTitle}>{bucketName}</Text>
         <IconButton
           icon="home"
           size={22}
@@ -886,7 +886,7 @@ function ProviderDetails({ provider, onBack }: ProviderDetailsProps) {
       </View>
       
       <View style={styles.bucketContentHeader}>
-        <Text style={styles.sectionTitle}>Bucket Contents</Text>
+        <Text style={styles.sectionTitle}>{bucketName}</Text>
         
         {currentPath && (
           <IconButton 


### PR DESCRIPTION
Simplify bucket header display by removing provider and location, and replacing "Bucket Contents" with the bucket name to reduce visual clutter.

---

[Open in Web](https://cursor.com/agents?id=bc-8f28bf12-b8aa-4008-a67e-4956daa4e3f9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8f28bf12-b8aa-4008-a67e-4956daa4e3f9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)