### PR TITLE
Rendre le chemin de navigation cliquable

### DIFF
--- a/src/components/ProviderDetails.tsx
+++ b/src/components/ProviderDetails.tsx
@@ -166,6 +166,9 @@ function ProviderDetails({ provider, onBack }: ProviderDetailsProps) {
   }
 
   function renderPathBreadcrumb() {
+    // Créer un tableau des segments du chemin
+    const pathSegments = currentPath ? currentPath.split('/').filter(segment => segment !== '') : [];
+    
     return (
       <View style={styles.breadcrumb}>
         <TouchableOpacity 
@@ -178,14 +181,40 @@ function ProviderDetails({ provider, onBack }: ProviderDetailsProps) {
           <Text style={styles.breadcrumbText}>Root</Text>
         </TouchableOpacity>
         
-        {currentPath && (
-          <>
-            <Text style={styles.breadcrumbSeparator}>/</Text>
-            <Text style={styles.breadcrumbCurrent} numberOfLines={1} ellipsizeMode="middle">
-              {currentPath}
-            </Text>
-          </>
-        )}
+        {pathSegments.map((segment, index) => {
+          // Calculer le chemin jusqu'à ce segment
+          const pathToSegment = pathSegments.slice(0, index + 1).join('/') + '/';
+          
+          return (
+            <React.Fragment key={index}>
+              <Text style={styles.breadcrumbSeparator}>/</Text>
+              <TouchableOpacity 
+                onPress={() => {
+                  // Naviguer vers ce segment du chemin
+                  const newPathHistory = [];
+                  let tempPath = '';
+                  
+                  // Reconstruire l'historique jusqu'à ce segment
+                  for (let i = 0; i < index; i++) {
+                    newPathHistory.push(tempPath);
+                    tempPath = tempPath ? `${tempPath}${pathSegments[i]}/` : `${pathSegments[i]}/`;
+                  }
+                  
+                  setPathHistory(newPathHistory);
+                  setCurrentPath(pathToSegment);
+                }}
+                style={styles.breadcrumbItem}
+              >
+                <Text style={[
+                  styles.breadcrumbText,
+                  index === pathSegments.length - 1 && styles.breadcrumbCurrent
+                ]}>
+                  {segment}
+                </Text>
+              </TouchableOpacity>
+            </React.Fragment>
+          );
+        })}
       </View>
     );
   }


### PR DESCRIPTION
Make each segment of the path breadcrumb clickable to allow quick navigation to parent directories.

---

[Open in Web](https://cursor.com/agents?id=bc-9f6f6265-249c-4246-8ba9-eda2260f0a4d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9f6f6265-249c-4246-8ba9-eda2260f0a4d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)