### PR TITLE
Implement RNCSafeAreaProvider component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "react-icons": "^5.5.0",
         "react-native": "0.76.9",
         "react-native-get-random-values": "^1.11.0",
-        "react-native-paper": "^5.13.4"
+        "react-native-paper": "^5.13.4",
+        "react-native-safe-area-context": "^5.6.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -10906,11 +10907,10 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
-      "integrity": "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.0.tgz",
+      "integrity": "sha512-tJas3YOdsuCg3kepCTGF3LWZp9onMbb9Agju2xfs2kRX8d/5TMUPmupBpjerk/B7Tv/zeJnk+qp5neA96Y0otQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-icons": "^5.5.0",
     "react-native": "0.76.9",
     "react-native-get-random-values": "^1.11.0",
-    "react-native-paper": "^5.13.4"
+    "react-native-paper": "^5.13.4",
+    "react-native-safe-area-context": "^5.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Install `react-native-safe-area-context` to resolve the `RNCSafeAreaProvider` unimplemented component error.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ef4f702-e722-4955-9b07-58b959357356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ef4f702-e722-4955-9b07-58b959357356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

