### PR TITLE
Overlay text on grid item images

### DIFF
--- a/src/components/GridFileItem.tsx
+++ b/src/components/GridFileItem.tsx
@@ -15,6 +15,7 @@ interface GridFileItemProps {
   onSelect?: () => void;
   size: 'small' | 'large'; // 'small' for 3x3, 'large' for 2x2
   showTitle?: boolean;
+  itemWidth: number; // Width calculated by parent component
 }
 
 export function GridFileItem({ 
@@ -26,10 +27,12 @@ export function GridFileItem({
   onPress, 
   onSelect,
   size,
-  showTitle = true
+  showTitle = true,
+  itemWidth
 }: GridFileItemProps) {
-  const itemSize = size === 'large' ? 120 : 80;
-  const iconSize = size === 'large' ? 64 : 48;
+  // Use itemWidth for both width and height to make square items
+  const itemSize = itemWidth;
+  const iconSize = size === 'large' ? itemWidth * 0.4 : itemWidth * 0.5;
   
   const handlePress = () => {
     if (isMultiSelect && onSelect) {
@@ -137,7 +140,7 @@ const styles = StyleSheet.create({
   gridItem: {
     backgroundColor: '#f8f9fa',
     borderRadius: 8,
-    margin: 4,
+    marginVertical: 1, // Minimal vertical margin
     position: 'relative',
     borderWidth: 1,
     borderColor: '#e0e0e0',

--- a/src/components/GridFileItem.tsx
+++ b/src/components/GridFileItem.tsx
@@ -29,7 +29,7 @@ export function GridFileItem({
   showTitle = true
 }: GridFileItemProps) {
   const itemSize = size === 'large' ? 120 : 80;
-  const iconSize = size === 'large' ? 48 : 32;
+  const iconSize = size === 'large' ? 64 : 48;
   
   const handlePress = () => {
     if (isMultiSelect && onSelect) {
@@ -39,14 +39,16 @@ export function GridFileItem({
     }
   };
 
-  const renderIcon = () => {
+  const renderBackgroundContent = () => {
     if (item.isFolder) {
       return (
-        <List.Icon 
-          icon="folder" 
-          color="#FFC107" 
-          style={{ alignSelf: 'center' }}
-        />
+        <View style={styles.backgroundIconContainer}>
+          <List.Icon 
+            icon="folder" 
+            color="rgba(255, 193, 7, 0.8)" 
+            size={iconSize}
+          />
+        </View>
       );
     } else if (isImageFile(item.name)) {
       return (
@@ -54,17 +56,19 @@ export function GridFileItem({
           item={item} 
           provider={provider} 
           bucketName={bucketName}
-          color="#2196F3" 
-          size={iconSize} 
+          size={itemSize}
+          fillContainer={true}
         />
       );
     } else {
       return (
-        <List.Icon 
-          icon="file" 
-          color="#2196F3" 
-          style={{ alignSelf: 'center' }}
-        />
+        <View style={styles.backgroundIconContainer}>
+          <List.Icon 
+            icon="file" 
+            color="rgba(33, 150, 243, 0.8)" 
+            size={iconSize}
+          />
+        </View>
       );
     }
   };
@@ -79,6 +83,12 @@ export function GridFileItem({
       onPress={handlePress}
       activeOpacity={0.7}
     >
+      {/* Background content (image/icon) fills entire container */}
+      <View style={styles.backgroundContainer}>
+        {renderBackgroundContent()}
+      </View>
+
+      {/* Overlay content */}
       {isMultiSelect && (
         <View style={styles.checkboxContainer}>
           <Checkbox
@@ -88,31 +98,27 @@ export function GridFileItem({
         </View>
       )}
       
-      <View style={[styles.iconContainer, !showTitle && styles.iconContainerNoTitle]}>
-        {renderIcon()}
-      </View>
-      
       {showTitle && (
-        <>
-          <View style={styles.titleContainer}>
+        <View style={styles.overlayContainer}>
+          <View style={styles.textOverlay}>
             <Text 
               style={[
-                styles.title, 
-                size === 'small' && styles.smallTitle
+                styles.overlayTitle, 
+                size === 'small' && styles.smallOverlayTitle
               ]} 
               numberOfLines={2}
               ellipsizeMode="middle"
             >
               {item.name}
             </Text>
+            
+            {!item.isFolder && (
+              <Text style={styles.overlaySubtitle} numberOfLines={1}>
+                {formatSize(item.size)}
+              </Text>
+            )}
           </View>
-          
-          {!item.isFolder && (
-            <Text style={styles.subtitle} numberOfLines={1}>
-              {formatSize(item.size)}
-            </Text>
-          )}
-        </>
+        </View>
       )}
     </TouchableOpacity>
   );
@@ -131,58 +137,74 @@ const styles = StyleSheet.create({
   gridItem: {
     backgroundColor: '#f8f9fa',
     borderRadius: 8,
-    padding: 8,
     margin: 4,
-    alignItems: 'center',
-    justifyContent: 'space-between',
     position: 'relative',
     borderWidth: 1,
     borderColor: '#e0e0e0',
+    overflow: 'hidden', // Ensures content doesn't overflow rounded corners
   },
   selectedItem: {
     backgroundColor: '#E3F2FD',
     borderColor: '#2196F3',
+    borderWidth: 2,
+  },
+  backgroundContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backgroundIconContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: '100%',
   },
   checkboxContainer: {
     position: 'absolute',
     top: 4,
     right: 4,
+    zIndex: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 12,
+  },
+  overlayContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
     zIndex: 1,
   },
-  iconContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: 8,
+  textOverlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
   },
-  iconContainerNoTitle: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginTop: 0,
-  },
-  titleContainer: {
-    paddingHorizontal: 4,
-    paddingVertical: 2,
-    backgroundColor: 'rgba(255, 255, 255, 0.9)',
-    borderRadius: 4,
-    marginTop: 4,
-    minHeight: 28,
-    justifyContent: 'center',
-  },
-  title: {
+  overlayTitle: {
     fontSize: 11,
-    fontWeight: '500',
+    fontWeight: '600',
     textAlign: 'center',
-    color: '#333',
+    color: '#ffffff',
+    textShadowColor: 'rgba(0, 0, 0, 0.8)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
   },
-  smallTitle: {
+  smallOverlayTitle: {
     fontSize: 9,
   },
-  subtitle: {
+  overlaySubtitle: {
     fontSize: 9,
-    color: '#666',
-    marginTop: 2,
+    color: '#e0e0e0',
+    marginTop: 1,
     textAlign: 'center',
+    textShadowColor: 'rgba(0, 0, 0, 0.8)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
   },
 });

--- a/src/components/GridFileItem.tsx
+++ b/src/components/GridFileItem.tsx
@@ -101,7 +101,8 @@ export function GridFileItem({
         </View>
       )}
       
-      {showTitle && (
+      {/* Always show titles for folders and non-image files, or when showTitle is true for images */}
+      {(showTitle || item.isFolder || !isImageFile(item.name)) && (
         <View style={styles.overlayContainer}>
           <View style={styles.textOverlay}>
             <Text 

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -34,11 +34,12 @@ export function GridView({
   const numColumns = viewMode === 'grid2' ? 2 : 3;
   const itemSize = viewMode === 'grid2' ? 'large' : 'small';
   
-  // Calculate item width based on screen width and number of columns
-  const padding = 16; // Container padding
-  const spacing = 8; // Space between items
-  const availableWidth = screenWidth - (padding * 2);
-  const itemWidth = (availableWidth - (spacing * (numColumns - 1))) / numColumns;
+  // Calculate item width with minimal spacing
+  const containerPadding = 4; // Minimal container padding
+  const itemSpacing = 2; // Minimal space between items
+  const availableWidth = screenWidth - (containerPadding * 2);
+  const totalSpacing = itemSpacing * (numColumns - 1);
+  const itemWidth = (availableWidth - totalSpacing) / numColumns;
 
   const renderItem = ({ item }: { item: S3Object }) => (
     <GridFileItem
@@ -49,6 +50,7 @@ export function GridView({
       isMultiSelect={isMultiSelect}
       size={itemSize}
       showTitle={showTitles}
+      itemWidth={itemWidth}
       onPress={() => onItemPress(item)}
       onSelect={() => onItemSelect(item)}
     />
@@ -61,10 +63,13 @@ export function GridView({
       numColumns={numColumns}
       key={`${viewMode}-${numColumns}`} // Force re-render when changing columns
       contentContainerStyle={{ 
-        padding: 8,
+        padding: containerPadding,
         paddingBottom: 80, // Extra space for FAB
       }}
-      columnWrapperStyle={numColumns > 1 ? { justifyContent: 'space-around' } : undefined}
+      columnWrapperStyle={numColumns > 1 ? { 
+        justifyContent: 'space-between',
+        paddingHorizontal: 0,
+      } : undefined}
       showsVerticalScrollIndicator={false}
       refreshControl={
         onRefresh ? (

--- a/src/components/ImageThumbnail.tsx
+++ b/src/components/ImageThumbnail.tsx
@@ -9,23 +9,49 @@ interface ImageThumbnailProps {
   bucketName: string;
   color?: string;
   size?: number;
+  fillContainer?: boolean;
 }
 
 /**
  * Component that displays an image thumbnail for image files,
  * with fallback to generic file icon on error
  */
-export function ImageThumbnail({ item, provider, bucketName, color = '#2196F3', size = 24 }: ImageThumbnailProps) {
+export function ImageThumbnail({ 
+  item, 
+  provider, 
+  bucketName, 
+  color = '#2196F3', 
+  size = 24, 
+  fillContainer = false 
+}: ImageThumbnailProps) {
   const [imageError, setImageError] = useState(false);
   
   // If there was an error loading the image, show generic file icon
   if (imageError) {
+    if (fillContainer) {
+      return (
+        <View style={styles.fullContainer}>
+          <List.Icon icon="file" color="rgba(33, 150, 243, 0.8)" size={size * 0.6} />
+        </View>
+      );
+    }
     return <List.Icon icon="file" color={color} />;
   }
 
   // Construct the image URL
   // This assumes the S3 object is publicly accessible or you have proper authentication
   const imageUrl = `${provider.endpoint}/${bucketName}/${item.key}`;
+
+  if (fillContainer) {
+    return (
+      <Image
+        source={{ uri: imageUrl }}
+        style={styles.fullImage}
+        onError={() => setImageError(true)}
+        resizeMode="cover"
+      />
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -48,5 +74,16 @@ const styles = StyleSheet.create({
   },
   thumbnail: {
     borderRadius: 4,
+  },
+  fullContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: '100%',
+  },
+  fullImage: {
+    width: '100%',
+    height: '100%',
   },
 });


### PR DESCRIPTION
Redesign grid view items to display images/icons filling the entire space with name and size text overlaid for a modern layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a6bf4d4-2ceb-4a97-9f4b-e0415f65dc2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a6bf4d4-2ceb-4a97-9f4b-e0415f65dc2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

