### PR TITLE
Investigate s3 compatible image preview issues

### DIFF
--- a/src/components/ImageThumbnail.tsx
+++ b/src/components/ImageThumbnail.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Image, StyleSheet } from 'react-native';
 import { List } from 'react-native-paper';
-import { S3Object } from '../types';
+import { S3Object, S3Provider } from '../types';
+import { getSignedObjectUrl } from '../services/s3Service';
 
 interface ImageThumbnailProps {
   item: S3Object;
-  provider: any; // Provider info for constructing image URL
+  provider: S3Provider;
   bucketName: string;
   color?: string;
   size?: number;
@@ -25,9 +26,62 @@ export function ImageThumbnail({
   fillContainer = false 
 }: ImageThumbnailProps) {
   const [imageError, setImageError] = useState(false);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const generateImageUrl = async () => {
+      try {
+        setLoading(true);
+        
+        // For AWS S3, we can try direct URL first (for public buckets)
+        // For other providers, we always use signed URLs
+        if (provider.type === 'aws') {
+          // Try direct URL first for AWS (backward compatibility)
+          const directUrl = `${provider.endpoint}/${bucketName}/${item.key}`;
+          setImageUrl(directUrl);
+        } else {
+          // For S3-compatible providers like Hetzner, always use signed URLs
+          const signedUrl = await getSignedObjectUrl(provider, bucketName, item.key, 3600); // 1 hour expiry
+          if (isMounted) {
+            setImageUrl(signedUrl);
+          }
+        }
+      } catch (error) {
+        console.error('Error generating image URL:', error);
+        if (isMounted) {
+          setImageError(true);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    generateImageUrl();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [provider, bucketName, item.key]);
+
+  // Show loading state
+  if (loading) {
+    if (fillContainer) {
+      return (
+        <View style={styles.fullContainer}>
+          <List.Icon icon="loading" color="rgba(33, 150, 243, 0.8)" size={size * 0.6} />
+        </View>
+      );
+    }
+    return <List.Icon icon="loading" color={color} />;
+  }
   
-  // If there was an error loading the image, show generic file icon
-  if (imageError) {
+  // If there was an error loading the image or no URL, show generic file icon
+  if (imageError || !imageUrl) {
     if (fillContainer) {
       return (
         <View style={styles.fullContainer}>
@@ -38,16 +92,26 @@ export function ImageThumbnail({
     return <List.Icon icon="file" color={color} />;
   }
 
-  // Construct the image URL
-  // This assumes the S3 object is publicly accessible or you have proper authentication
-  const imageUrl = `${provider.endpoint}/${bucketName}/${item.key}`;
+  const handleImageError = async () => {
+    // If direct URL failed for AWS, try signed URL as fallback
+    if (provider.type === 'aws' && imageUrl?.includes(provider.endpoint)) {
+      try {
+        const signedUrl = await getSignedObjectUrl(provider, bucketName, item.key, 3600);
+        setImageUrl(signedUrl);
+        return; // Don't set error state, try the signed URL
+      } catch (error) {
+        console.error('Error generating signed URL fallback:', error);
+      }
+    }
+    setImageError(true);
+  };
 
   if (fillContainer) {
     return (
       <Image
         source={{ uri: imageUrl }}
         style={styles.fullImage}
-        onError={() => setImageError(true)}
+        onError={handleImageError}
         resizeMode="cover"
       />
     );
@@ -58,7 +122,7 @@ export function ImageThumbnail({
       <Image
         source={{ uri: imageUrl }}
         style={[styles.thumbnail, { width: size, height: size }]}
-        onError={() => setImageError(true)}
+        onError={handleImageError}
         resizeMode="cover"
       />
     </View>

--- a/src/services/s3Service.ts
+++ b/src/services/s3Service.ts
@@ -191,6 +191,8 @@ export function extractBucketName(provider: S3Provider): string {
 
 /**
  * Get URL for downloading or viewing an object
+ * Note: This function returns direct URLs which may not work for private buckets.
+ * For authenticated access, use getSignedObjectUrl instead.
  */
 export function getObjectUrl(provider: S3Provider, bucketName: string, key: string): string {
   // Most S3-compatible providers use path-style URLs


### PR DESCRIPTION
Use signed URLs for image previews to support all S3-compatible providers and private AWS S3 buckets.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa869c11-c5ac-405a-a8d2-f90c5ca4d29e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa869c11-c5ac-405a-a8d2-f90c5ca4d29e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

