### PR TITLE
Copy object and key to clipboard

### DIFF
--- a/src/components/ProviderDetails.tsx
+++ b/src/components/ProviderDetails.tsx
@@ -436,7 +436,7 @@ function ProviderDetails({ provider, onBack }: ProviderDetailsProps) {
   }
 
   // Fonctions pour la copie et le renommage d'éléments (dossiers et fichiers)
-  function handleCopyItem(item: S3Object) {
+  async function handleCopyItem(item: S3Object) {
     // Set both local and global clipboard for cross-bucket functionality
     setCopiedItem(item);
     setClipboardData({
@@ -445,10 +445,17 @@ function ProviderDetails({ provider, onBack }: ProviderDetailsProps) {
       sourceBucket: bucketName
     });
     
+    // Also copy the object key (path) to system clipboard
+    try {
+      await Clipboard.setStringAsync(item.fullPath || item.key);
+    } catch (error) {
+      console.error('Error copying path to clipboard:', error);
+    }
+    
     const itemType = item.isFolder ? 'dossier' : 'fichier';
     Alert.alert(
       `${itemType.charAt(0).toUpperCase() + itemType.slice(1)} copié`, 
-      `Le ${itemType} "${item.name}" a été copié et peut être collé dans n'importe quel bucket.`
+      `Le ${itemType} "${item.name}" a été copié et peut être collé dans n'importe quel bucket. Le chemin a aussi été copié dans le presse-papiers.`
     );
   }
 


### PR DESCRIPTION
Copy the object's key (path) to the system clipboard when an object is copied within a bucket.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb05b36b-b2f5-4953-87fb-c645ad367337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb05b36b-b2f5-4953-87fb-c645ad367337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

